### PR TITLE
Make the website title (h1 tag) clickable to redirect to the home page and update styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,9 @@
         class="flex-row justify-content-btw align-items-center headerdata"
       >
         <div>
-          <h1 class="grow-2" id="logo">Giphy Search</h1>
+          <a href="https://lcrojano.github.io/Giphy_Explorer/" class="logo-link">
+            <h1 class="grow-2" id="logo">Giphy Search</h1>
+          </a>
           <caption>
             By Luis Rojano
           </caption>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -64,6 +64,11 @@ h1 {
    position: relative;
 }
 
+.logo-link {
+    text-decoration: none;
+    color: var(--primary-text-color);
+}
+
 .fixedlogo {
     position: fixed;
     top: -60px;  

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -29,6 +29,10 @@
   filter: invert(1); /* Change the icon color to black */
 }
 
+.dark-mode .logo-link h1 {
+  color: var(--principal-text-color);
+}
+
 #myBtn {
     display: none;
     position: fixed;


### PR DESCRIPTION
Fixes #61 

## Description
This PR addresses two main issues:

1. Made the website's title (`<h1 id="logo">Giphy Search</h1>`) clickable, allowing users to return to the home page when clicking the title.
2. Updated the color of the title in dark mode to ensure it is easily readable.

### Changes Made:
- Wrapped the `<h1>` tag inside an `<a>` tag to redirect to the home page.
- Added a CSS rule to set the color of the title to white (`var(--principal-text-color)`) in dark mode.

## Testing
- Verified that clicking the title redirects to the home page.
- Confirmed the title appears white in dark mode for better visibility.

## Note
Changes were made without the influence of automatic formatting tools to ensure clarity of the functional updates.