### PR TITLE
Improve Search Box Background Color in Dark Mode

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -133,6 +133,11 @@ input[type='search']::placeholder {
   color: #bbb;
 }
 
+.dark-mode input[type='search'] {
+    background: var(--principal-text-color); /* White background in dark mode */
+    color: var(--primary-text-color); /* Black text in dark mode */
+} 
+
 #search-btn,
 #toggle,
 #fav-btn,


### PR DESCRIPTION
Fixes #67 

#### Description:
This PR updates the search box background and text color specifically for dark mode to improve readability and user experience.

#### Changes:
- In dark mode, the search box background is now `--principal-text-color` (white).
- The text inside the search box is now `--primary-text-color` (black) in dark mode.

#### Before:
- The search box had the same background (`--primary-text-color: #121212;`) in both light and dark modes, making it harder to see in dark mode.

#### After:
- The search box now has a white background and black text in dark mode for better contrast and readability.

#### Testing:
- Verified in both light and dark modes that the search box correctly switches background and text color.
  
#### Screenshots:
*Before*
![image](https://github.com/user-attachments/assets/9df174dd-930a-4c5b-ad8a-5402a64f9565)

*After*
![image](https://github.com/user-attachments/assets/641efec8-d3b2-4900-b448-bb8f1075375d)

---

Feel free to review and provide any feedback. Thanks!