### PR TITLE
Fixed the remove from favourites issue

### DIFF
--- a/scripts/favs.js
+++ b/scripts/favs.js
@@ -52,49 +52,52 @@ const setFavs = function () {
   let url;
 
   gifs.forEach((gif) => {
-    let figure = document.createElement('figure', { class: 'figure' }); //Este no esta en el dom todavia
+    let figure = document.createElement('figure', { class: 'figure' });
     figure.innerHTML = `
-			<picture class="picture ">
-				<source srcset="${gif.imageUrl}" type="image/png" media="(min-width:1920px)">
-				<source srcset="${gif.imageUrl}" type="image/png" media="(min-width:1200px)">
-				<source srcset="${gif.imageUrl}" type="image/png" media="(min-width:700px)">
-				<image src="${gif.imageUrl}" alt="test" class="abc">
-			</picture>
-			<figcaption>
-					<div class="autor flex-row aling-items-center">
-							<img src="${gif.authorImage} "
-					</div>
-					<div class="info flex-col " >
-							<p><strong>${gif.authorName || 'autor'}</strong></p>
-					</div>
-           <button class="remove-fav-btn">Remove from Favorites</button>
-			</figcaption>
-		`;
-    let text, description;
-    figure.addEventListener('click', (e) => {
-      modal.classList.add('display-modal');
-      url = e.target.src;
-      text = 'Check out this amazing Gif!';
-      description = 'Check out this amazing Gif!';
+      <picture class="picture ">
+        <source srcset="${gif.imageUrl}" type="image/png" media="(min-width:1920px)">
+        <source srcset="${gif.imageUrl}" type="image/png" media="(min-width:1200px)">
+        <source srcset="${gif.imageUrl}" type="image/png" media="(min-width:700px)">
+        <image src="${gif.imageUrl}" alt="test" class="abc">
+      </picture>
+      <figcaption>
+        <div class="autor flex-row aling-items-center">
+          <img src="${gif.authorImage}" />
+        </div>
+        <div class="info flex-col">
+          <p><strong>${gif.authorName || 'autor'}</strong></p>
+        </div>
+        <button class="remove-fav-btn">Remove from Favorites</button>
+      </figcaption>
+    `;
 
-      figure.querySelector('.remove-fav-btn').addEventListener('click', (e) => {
-        removeFav(gif.imageUrl);
-        figure.remove();  // Remove the GIF from the DOM
+    // Event listener for removing the favorite (outside modal logic)
+    figure.querySelector('.remove-fav-btn').addEventListener('click', (e) => {
+      e.stopPropagation();  // Prevents the modal from being triggered on remove
+      removeFav(gif.imageUrl);  // Remove GIF from localStorage using its imageUrl
+      figure.remove();  // Remove the GIF from the DOM
     });
 
     fragment.appendChild(figure);
+
+    // Modal logic
+    figure.addEventListener('click', (e) => {
+      modal.classList.add('display-modal');
+      url = e.target.src;
+
+      // Close button listener
+      modal.querySelector('#close').addEventListener('click', () => {
+        modal.classList.remove('display-modal');
+      });
+
       modal.addEventListener('click', (e) => {
         if (e.target.id === 'fav') {
           removeFav(url);
           e.target.textContent = 'Removed';
         }
-
         if (e.target.id === 'copy') {
           navigator.clipboard.writeText(url);
-          // Show "Copied" message
           e.target.textContent = 'Copied';
-
-          // Reset the button text to "Copy" after 2 seconds (2000 milliseconds)
           setTimeout(() => {
             e.target.textContent = 'Copy';
           }, 2000);
@@ -103,37 +106,25 @@ const setFavs = function () {
           shareOnFacebook(url);
         }
         if (e.target.id === 'share-twitter') {
-          shareOnTwitter(url, text);
+          shareOnTwitter(url, 'Check out this amazing Gif!');
         }
         if (e.target.id === 'share-pinterest') {
-          shareOnPinterest(url, url, description);
+          shareOnPinterest(url, url, 'Check out this amazing Gif!');
         }
-        // if(e.target.id === 'share-insta'){
-        //   shareOnInstagram(url,description);
-        // }
       });
     });
-    modal.addEventListener('click', (e) => {
-      if (e.target.id === 'close' || e.target.id === 'modal-overlay') {
-        modal.classList.remove('display-modal');
-      }
-      if (e.target.id === 'copy') {
-        console.log(url);
-      }
-    });
-
-    fragment.appendChild(figure);
   });
+
   main.appendChild(fragment);
 };
 
+// Updated removeFav function
 const removeFav = function (url) {
-  const localStorage = window.localStorage;
-  const favsString = localStorage.getItem('gifs');
-  const favs = favsString ? JSON.parse(favsString) : {};
-  delete favs[url];
-  const newFavs = JSON.stringify(favs);
-  localStorage.setItem('gifs', newFavs);
+  let favs = getFavs();  // Get current favorites
+  favs.delete(url);  // Remove the GIF from the Map using the imageUrl as the key
+  const newFavs = JSON.stringify(Object.fromEntries(favs));  // Convert Map back to an object
+  localStorage.setItem('gifs', newFavs);  // Update localStorage with the new state
 };
 
 setFavs();
+


### PR DESCRIPTION
Fixes #83 

## Summary

This PR addresses the following issues and implements several key features for the Giphy Explorer project:

- **Bug Fix:** Fixed the modal close button functionality, which was previously not working. Now, users can properly close the "Share GIF" modal using the cross button.
- **Feature Addition:** Added the ability to upload GIFs directly through the file upload option, and ensured only GIF files are accepted.

## Changes Made

1. **Modal Close Button:**
   - Fixed the close button functionality by adding an event listener that removes the modal from view when the button is clicked.
   
2. **File Upload Handling:**
   - Implemented an event listener that allows users to upload GIF files.
   - Restricted the file type to only accept `.gif` images.

3. **Favorites Management:**
   - Added functionality to remove GIFs from favorites, both in the modal and the main list.

## How to Test

1. **GIF Upload:**
   - Click on the "Upload GIF" button and choose a `.gif` file from your system.
   - Ensure that non-GIF files are rejected.

2. **Sharing and Removing GIFs:**
   - Click on a GIF to open the modal.
   - Test the share buttons for Facebook, Twitter, and Pinterest.
   - Test the "Copy Link" button and ensure the URL is copied.
   - Click on "Remove" to remove the GIF from your favorites list.

3. **Close Button:**
   - Open the modal by clicking on a GIF and close it using the cross button (top-right corner).

---

Let me know if you'd like to see any further changes, or if you encounter any issues while testing this PR.